### PR TITLE
Feat: Implement ordered block display in storage GUI based on config.yml sequence

### DIFF
--- a/src/main/java/net/danh/storage/CMD/StorageCMD.java
+++ b/src/main/java/net/danh/storage/CMD/StorageCMD.java
@@ -44,14 +44,12 @@ public class StorageCMD extends CMDBase {
                     Player p = (Player) c;
                     if (p.hasPermission("storage.toggle")) {
                         MineManager.toggle.replace(p, !MineManager.toggle.get(p));
-                        p.sendMessage(Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.status.toggle"))
-                                .replace("#status#", ItemManager.getStatus(p))));
+                        p.sendMessage(Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.status.toggle")).replace("#status#", ItemManager.getStatus(p))));
                     }
                 }
             }
         }
-        if (c.hasPermission("storage.admin")
-                || c.hasPermission("storage.admin.reload")) {
+        if (c.hasPermission("storage.admin") || c.hasPermission("storage.admin.reload")) {
             if (args.length == 1) {
                 if (args[0].equalsIgnoreCase("reload")) {
                     File.reloadFiles();
@@ -64,8 +62,7 @@ public class StorageCMD extends CMDBase {
                 }
             }
         }
-        if (c.hasPermission("storage.admin")
-                || c.hasPermission("storage.admin.max")) {
+        if (c.hasPermission("storage.admin") || c.hasPermission("storage.admin.max")) {
             if (args.length == 3) {
                 if (args[0].equalsIgnoreCase("max")) {
                     Player p = Bukkit.getPlayer(args[1]);
@@ -79,8 +76,7 @@ public class StorageCMD extends CMDBase {
                 }
             }
         }
-        if (c.hasPermission("storage.admin")
-                || c.hasPermission("storage.admin.add") || c.hasPermission("storage.admin.remove") || c.hasPermission("storage.admin.set")) {
+        if (c.hasPermission("storage.admin") || c.hasPermission("storage.admin.add") || c.hasPermission("storage.admin.remove") || c.hasPermission("storage.admin.set")) {
             if (args.length == 4) {
                 if (MineManager.getPluginBlocks().contains(args[1])) {
                     Player p = Bukkit.getPlayer(args[2]);
@@ -88,8 +84,7 @@ public class StorageCMD extends CMDBase {
                         int number = Number.getInteger(args[3]);
                         if (number >= 0) {
                             if (args[0].equalsIgnoreCase("add")) {
-                                if (c.hasPermission("storage.admin")
-                                        || c.hasPermission("storage.admin.add")) {
+                                if (c.hasPermission("storage.admin") || c.hasPermission("storage.admin.add")) {
                                     if (MineManager.addBlockAmount(p, args[1], number)) {
                                         c.sendMessage(Chat.colorize(File.getMessage().getString("admin.add_material_amount")).replace("#amount#", args[3]).replace("#material#", args[1]).replace("#player#", p.getName()));
                                         p.sendMessage(Chat.colorize(File.getMessage().getString("user.add_material_amount")).replace("#amount#", args[3]).replace("#material#", args[1]).replace("#player#", c.getName()));
@@ -145,16 +140,14 @@ public class StorageCMD extends CMDBase {
             StringUtil.copyPartialMatches(args[0], commands, completions);
         }
         if (args.length == 2) {
-            if (sender.hasPermission("storage.admin")
-                    || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
+            if (sender.hasPermission("storage.admin") || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
                 if (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("set")) {
                     if (commands.addAll(MineManager.getPluginBlocks())) {
                         StringUtil.copyPartialMatches(args[1], commands, completions);
                     }
                 }
             }
-            if (sender.hasPermission("storage.admin")
-                    || sender.hasPermission("storage.admin.max")) {
+            if (sender.hasPermission("storage.admin") || sender.hasPermission("storage.admin.max")) {
                 if (args[0].equalsIgnoreCase("max")) {
                     Bukkit.getServer().getOnlinePlayers().forEach(player -> commands.add(player.getName()));
                     StringUtil.copyPartialMatches(args[1], commands, completions);
@@ -162,8 +155,7 @@ public class StorageCMD extends CMDBase {
             }
         }
         if (args.length == 3) {
-            if (sender.hasPermission("storage.admin")
-                    || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
+            if (sender.hasPermission("storage.admin") || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
                 if (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("set")) {
                     if (MineManager.getPluginBlocks().contains(args[1])) {
                         Bukkit.getServer().getOnlinePlayers().forEach(player -> commands.add(player.getName()));
@@ -171,16 +163,14 @@ public class StorageCMD extends CMDBase {
                     }
                 }
             }
-            if (sender.hasPermission("storage.admin")
-                    || sender.hasPermission("storage.admin.max")) {
+            if (sender.hasPermission("storage.admin") || sender.hasPermission("storage.admin.max")) {
                 if (args[0].equalsIgnoreCase("max")) {
                     StringUtil.copyPartialMatches(args[2], Collections.singleton("<number>"), completions);
                 }
             }
         }
         if (args.length == 4) {
-            if (sender.hasPermission("storage.admin")
-                    || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
+            if (sender.hasPermission("storage.admin") || sender.hasPermission("storage.admin.add") || sender.hasPermission("storage.admin.remove") || sender.hasPermission("storage.admin.set")) {
                 if (args[0].equalsIgnoreCase("add") || args[0].equalsIgnoreCase("remove") || args[0].equalsIgnoreCase("set")) {
                     if (MineManager.getPluginBlocks().contains(args[1])) {
                         StringUtil.copyPartialMatches(args[3], Collections.singleton("<number>"), completions);

--- a/src/main/java/net/danh/storage/GUI/PersonalStorage.java
+++ b/src/main/java/net/danh/storage/GUI/PersonalStorage.java
@@ -38,7 +38,7 @@ public class PersonalStorage implements IGUI {
             if (item_tag.equalsIgnoreCase("storage_item")) {
                 if (slot.contains(",")) {
                     List<String> slot_list = new ArrayList<>(Arrays.asList(slot.split(",")));
-                    List<String> item_list = new ArrayList<>(MineManager.getPluginBlocks());
+                    List<String> item_list = new ArrayList<>(MineManager.getOrderedPluginBlocks());
                     for (int i = 0; i < item_list.size(); i++) {
                         String material = MineManager.getMaterial(item_list.get(i));
                         String name = File.getConfig().getString("items." + item_list.get(i));

--- a/src/main/java/net/danh/storage/Manager/MineManager.java
+++ b/src/main/java/net/danh/storage/Manager/MineManager.java
@@ -39,6 +39,38 @@ public class MineManager {
         return new ArrayList<>(blocksdata.values());
     }
 
+    @Contract(" -> new")
+    public static @NotNull List<String> getOrderedPluginBlocks() {
+        List<String> orderedBlocks = new ArrayList<>();
+        for (String block_break : Objects.requireNonNull(File.getConfig().getConfigurationSection("blocks")).getKeys(false)) {
+            String item_drop = File.getConfig().getString("blocks." + block_break + ".drop");
+            NMSAssistant nms = new NMSAssistant();
+            if (item_drop != null) {
+                if (!item_drop.contains(";")) {
+                    String material = item_drop + ";0";
+                    if (!orderedBlocks.contains(material)) {
+                        orderedBlocks.add(material);
+                    }
+                } else {
+                    if (nms.isVersionLessThanOrEqualTo(12)) {
+                        String[] item_data = item_drop.split(";");
+                        String item_material = item_data[0] + ";" + item_data[1];
+                        if (!orderedBlocks.contains(item_material)) {
+                            orderedBlocks.add(item_material);
+                        }
+                    } else {
+                        String[] item_data = item_drop.split(";");
+                        String material = item_data[0] + ";0";
+                        if (!orderedBlocks.contains(material)) {
+                            orderedBlocks.add(material);
+                        }
+                    }
+                }
+            }
+        }
+        return orderedBlocks;
+    }
+
     public static void addPluginBlocks(String material) {
         blocksdata.put(material, material);
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -96,6 +96,7 @@ blocks:
     drop: EMERALD;0
   EMERALD_BLOCK;0:
     drop: EMERALD_BLOCK;0
+
 items:
   COBBLESTONE;0: "&7Cobblestone"
   COAL;0: "&8Coal"
@@ -112,6 +113,7 @@ items:
   DIAMOND_BLOCK;0: "&bDiamond Block"
   EMERALD;0: "&aEmerald"
   EMERALD_BLOCK;0: "&aEmerald Block"
+
 mine:
   title:
     enable: true


### PR DESCRIPTION
## New Feature: Storage GUI Block Ordering

Changed block display in Storage GUI from random HashMap order to config.yml sequential order.

- Added `MineManager.getOrderedPluginBlocks()`
- Updated `PersonalStorage.java` to use ordered method
- Blocks now display in config.yml sequence

**Result:** COBBLESTONE → COAL → COAL_BLOCK... following exact config order

<img width="925" height="530" alt="2025-07-23_21 30 51" src="https://github.com/user-attachments/assets/c54d8dcd-3f1a-4955-aee1-e8a5a4c3ef43" />
