### PR TITLE
New Feature: Pages on Storage gui

### DIFF
--- a/src/main/java/net/danh/storage/CMD/StorageCMD.java
+++ b/src/main/java/net/danh/storage/CMD/StorageCMD.java
@@ -26,7 +26,9 @@ public class StorageCMD extends CMDBase {
         if (args.length == 0) {
             if (c instanceof Player) {
                 try {
-                    ((Player) c).openInventory(new PersonalStorage((Player) c).getInventory());
+                    Player player = (Player) c;
+                    int currentPage = PersonalStorage.getPlayerCurrentPage(player);
+                    player.openInventory(new PersonalStorage(player, currentPage).getInventory());
                 } catch (IndexOutOfBoundsException e) {
                     c.sendMessage(Chat.colorize(File.getMessage().getString("admin.not_enough_slot")));
                 }

--- a/src/main/java/net/danh/storage/GUI/ItemStorage.java
+++ b/src/main/java/net/danh/storage/GUI/ItemStorage.java
@@ -25,18 +25,23 @@ public class ItemStorage implements IGUI {
 
     private final String material;
     private final FileConfiguration config;
+    private final int returnPage;
 
     public ItemStorage(Player p, String material) {
+        this(p, material, 0);
+    }
+
+    public ItemStorage(Player p, String material, int returnPage) {
         this.p = p;
         this.material = material;
+        this.returnPage = returnPage;
         config = File.getItemStorage();
     }
 
     @NotNull
     @Override
     public Inventory getInventory() {
-        Inventory inventory = Bukkit.createInventory(p, config.getInt("size") * 9, Chat.colorizewp(Objects.requireNonNull(config.getString("title")).replace("#player#", p.getName())
-                .replace("#material#", Objects.requireNonNull(File.getConfig().getString("items." + material, material.split(";")[0])))));
+        Inventory inventory = Bukkit.createInventory(p, config.getInt("size") * 9, Chat.colorizewp(Objects.requireNonNull(config.getString("title")).replace("#player#", p.getName()).replace("#material#", Objects.requireNonNull(File.getConfig().getString("items." + material, material.split(";")[0])))));
         for (String item_tag : Objects.requireNonNull(config.getConfigurationSection("items")).getKeys(false)) {
             String slot = Objects.requireNonNull(config.getString("items." + item_tag + ".slot")).replace(" ", "");
             if (slot.contains(",")) {
@@ -51,31 +56,34 @@ public class ItemStorage implements IGUI {
                             if (action_left.equalsIgnoreCase("deposit")) {
                                 if (type_left.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_deposit.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.deposit.chat_number")));
                                     p.closeInventory();
                                 } else if (type_left.equalsIgnoreCase("all")) {
                                     new Deposit(p, material, -1L).doAction();
-                                    p.openInventory(new PersonalStorage(p).getInventory());
+                                    p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                                 }
                             }
                             if (action_left.equalsIgnoreCase("withdraw")) {
                                 if (type_left.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_withdraw.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.withdraw.chat_number")));
                                     p.closeInventory();
                                 } else if (type_left.equalsIgnoreCase("all")) {
                                     new Withdraw(p, material, -1).doAction();
-                                    p.openInventory(new PersonalStorage(p).getInventory());
+                                    p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                                 }
                             }
                             if (action_left.equalsIgnoreCase("sell")) {
                                 if (type_left.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_sell.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.sell.chat_number")));
                                     p.closeInventory();
                                 } else if (type_left.equalsIgnoreCase("all")) {
                                     new Sell(p, material, -1).doAction();
-                                    p.openInventory(new PersonalStorage(p).getInventory());
+                                    p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                                 }
                             }
                             if (type_left.equalsIgnoreCase("command")) {
@@ -93,16 +101,18 @@ public class ItemStorage implements IGUI {
                             if (action_right.equalsIgnoreCase("deposit")) {
                                 if (type_right.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_deposit.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.deposit.chat_number")));
                                     p.closeInventory();
                                 } else if (type_right.equalsIgnoreCase("all")) {
                                     new Deposit(p, material, -1L).doAction();
-                                    p.openInventory(new PersonalStorage(p).getInventory());
+                                    p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                                 }
                             }
                             if (action_right.equalsIgnoreCase("withdraw")) {
                                 if (type_right.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_withdraw.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.withdraw.chat_number")));
                                     p.closeInventory();
                                 } else if (type_right.equalsIgnoreCase("all")) {
@@ -113,6 +123,7 @@ public class ItemStorage implements IGUI {
                             if (action_right.equalsIgnoreCase("sell")) {
                                 if (type_right.equalsIgnoreCase("chat")) {
                                     net.danh.storage.Listeners.Chat.chat_sell.put(p, material);
+                                    net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                     p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.sell.chat_number")));
                                     p.closeInventory();
                                 } else if (type_right.equalsIgnoreCase("all")) {
@@ -143,31 +154,34 @@ public class ItemStorage implements IGUI {
                         if (action_left.equalsIgnoreCase("deposit")) {
                             if (type_left.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_deposit.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.deposit.chat_number")));
                                 p.closeInventory();
                             } else if (type_left.equalsIgnoreCase("all")) {
                                 new Deposit(p, material, -1L).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (action_left.equalsIgnoreCase("withdraw")) {
                             if (type_left.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_withdraw.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.withdraw.chat_number")));
                                 p.closeInventory();
                             } else if (type_left.equalsIgnoreCase("all")) {
                                 new Withdraw(p, material, -1).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (action_left.equalsIgnoreCase("sell")) {
                             if (type_left.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_sell.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.sell.chat_number")));
                                 p.closeInventory();
                             } else if (type_left.equalsIgnoreCase("all")) {
                                 new Sell(p, material, -1).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (type_left.equalsIgnoreCase("command")) {
@@ -185,31 +199,34 @@ public class ItemStorage implements IGUI {
                         if (action_right.equalsIgnoreCase("deposit")) {
                             if (type_right.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_deposit.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.deposit.chat_number")));
                                 p.closeInventory();
                             } else if (type_right.equalsIgnoreCase("all")) {
                                 new Deposit(p, material, -1L).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (action_right.equalsIgnoreCase("withdraw")) {
                             if (type_right.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_withdraw.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.withdraw.chat_number")));
                                 p.closeInventory();
                             } else if (type_right.equalsIgnoreCase("all")) {
                                 new Withdraw(p, material, -1).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (action_right.equalsIgnoreCase("sell")) {
                             if (type_right.equalsIgnoreCase("chat")) {
                                 net.danh.storage.Listeners.Chat.chat_sell.put(p, material);
+                                net.danh.storage.Listeners.Chat.chat_return_page.put(p, returnPage);
                                 p.sendMessage(Chat.colorize(File.getMessage().getString("user.action.sell.chat_number")));
                                 p.closeInventory();
                             } else if (type_right.equalsIgnoreCase("all")) {
                                 new Sell(p, material, -1).doAction();
-                                p.openInventory(new PersonalStorage(p).getInventory());
+                                p.openInventory(new PersonalStorage(p, returnPage).getInventory());
                             }
                         }
                         if (type_right.equalsIgnoreCase("command")) {
@@ -238,5 +255,9 @@ public class ItemStorage implements IGUI {
 
     public String getMaterial() {
         return material;
+    }
+
+    public int getReturnPage() {
+        return returnPage;
     }
 }

--- a/src/main/java/net/danh/storage/GUI/PersonalStorage.java
+++ b/src/main/java/net/danh/storage/GUI/PersonalStorage.java
@@ -8,43 +8,74 @@ import net.danh.storage.Utils.Chat;
 import net.danh.storage.Utils.File;
 import net.danh.storage.Utils.Number;
 import org.bukkit.Bukkit;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class PersonalStorage implements IGUI {
 
+    public static HashMap<Player, Integer> playerCurrentPage = new HashMap<>();
     private final Player p;
     private final FileConfiguration config;
+    private final int currentPage;
 
     public PersonalStorage(Player p) {
+        this(p, 0);
+    }
+
+    public PersonalStorage(Player p, int page) {
         this.p = p;
+        this.currentPage = Math.max(0, page);
         config = File.getGUIStorage();
+        playerCurrentPage.put(p, this.currentPage);
+    }
+
+    public static int getPlayerCurrentPage(Player player) {
+        return playerCurrentPage.getOrDefault(player, 0);
     }
 
     @NotNull
     @Override
     public Inventory getInventory() {
         Inventory inventory = Bukkit.createInventory(p, config.getInt("size") * 9, Chat.colorizewp(Objects.requireNonNull(config.getString("title")).replace("#player#", p.getName())));
+        List<String> item_list = new ArrayList<>(MineManager.getOrderedPluginBlocks());
+        int itemsPerPage = Objects.requireNonNull(config.getString("items.storage_item.slot")).split(",").length;
+        int totalPages = Math.max(1, (int) Math.ceil((double) item_list.size() / itemsPerPage));
+        boolean hasMultiplePages = totalPages > 1;
+
+        Set<Integer> navigationSlots = new HashSet<>();
+        if (hasMultiplePages) {
+            if (config.contains("items.previous_page.slot")) {
+                navigationSlots.add(Integer.parseInt(config.getString("items.previous_page.slot")));
+            }
+            if (config.contains("items.next_page.slot")) {
+                navigationSlots.add(Integer.parseInt(config.getString("items.next_page.slot")));
+            }
+        }
+
         for (String item_tag : Objects.requireNonNull(config.getConfigurationSection("items")).getKeys(false)) {
             String slot = Objects.requireNonNull(config.getString("items." + item_tag + ".slot")).replace(" ", "");
             if (item_tag.equalsIgnoreCase("storage_item")) {
                 if (slot.contains(",")) {
                     List<String> slot_list = new ArrayList<>(Arrays.asList(slot.split(",")));
-                    List<String> item_list = new ArrayList<>(MineManager.getOrderedPluginBlocks());
-                    for (int i = 0; i < item_list.size(); i++) {
-                        String material = MineManager.getMaterial(item_list.get(i));
-                        String name = File.getConfig().getString("items." + item_list.get(i));
-                        ItemStack itemStack = ItemManager.getItemConfig(p, material, name != null ? name : item_list.get(i).split(";")[0], config.getConfigurationSection("items.storage_item"));
-                        InteractiveItem interactiveItem = new InteractiveItem(itemStack, Number.getInteger(slot_list.get(i))).onClick((player, clickType) -> player.openInventory(new ItemStorage(p, material).getInventory()));
-                        inventory.setItem(interactiveItem.getSlot(), interactiveItem);
+                    int startIndex = currentPage * itemsPerPage;
+                    int endIndex = Math.min(startIndex + itemsPerPage, item_list.size());
+                    for (int i = startIndex; i < endIndex; i++) {
+                        int slotIndex = i - startIndex;
+                        if (slotIndex < slot_list.size()) {
+                            String material = MineManager.getMaterial(item_list.get(i));
+                            String name = File.getConfig().getString("items." + item_list.get(i));
+                            ItemStack itemStack = ItemManager.getItemConfig(p, material, name != null ? name : item_list.get(i).split(";")[0], config.getConfigurationSection("items.storage_item"));
+                            InteractiveItem interactiveItem = new InteractiveItem(itemStack, Number.getInteger(slot_list.get(slotIndex))).onClick((player, clickType) -> player.openInventory(new ItemStorage(p, material, currentPage).getInventory()));
+                            inventory.setItem(interactiveItem.getSlot(), interactiveItem);
+                        }
                     }
                 }
             } else if (item_tag.equalsIgnoreCase("toggle_item")) {
@@ -53,7 +84,7 @@ public class PersonalStorage implements IGUI {
                         InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(p, Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), Number.getInteger(slot_string)).onClick((player, clickType) -> {
                             MineManager.toggle.replace(p, !MineManager.toggle.get(p));
                             p.sendMessage(Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.status.toggle")).replace("#status#", ItemManager.getStatus(p))));
-                            p.openInventory(this.getInventory());
+                            p.openInventory(new PersonalStorage(p, currentPage).getInventory());
                         });
                         inventory.setItem(item.getSlot(), item);
                     }
@@ -61,19 +92,42 @@ public class PersonalStorage implements IGUI {
                     InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(p, Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), Number.getInteger(slot)).onClick((player, clickType) -> {
                         MineManager.toggle.replace(p, !MineManager.toggle.get(p));
                         p.sendMessage(Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.status.toggle")).replace("#status#", ItemManager.getStatus(p))));
-                        p.openInventory(this.getInventory());
+                        p.openInventory(new PersonalStorage(p, currentPage).getInventory());
                     });
                     inventory.setItem(item.getSlot(), item);
+                }
+            } else if (item_tag.equalsIgnoreCase("previous_page")) {
+                if (hasMultiplePages && currentPage > 0) {
+                    ItemStack prevPageItem = getNavigationItem(item_tag, currentPage, totalPages);
+                    if (prevPageItem != null) {
+                        InteractiveItem item = new InteractiveItem(prevPageItem, Number.getInteger(slot)).onClick((player, clickType) -> player.openInventory(new PersonalStorage(p, currentPage - 1).getInventory()));
+                        inventory.setItem(item.getSlot(), item);
+                    }
+                }
+            } else if (item_tag.equalsIgnoreCase("next_page")) {
+                if (hasMultiplePages && currentPage < totalPages - 1) {
+                    ItemStack nextPageItem = getNavigationItem(item_tag, currentPage, totalPages);
+                    if (nextPageItem != null) {
+                        InteractiveItem item = new InteractiveItem(nextPageItem, Number.getInteger(slot)).onClick((player, clickType) -> player.openInventory(new PersonalStorage(p, currentPage + 1).getInventory()));
+                        inventory.setItem(item.getSlot(), item);
+                    }
                 }
             } else {
                 if (slot.contains(",")) {
                     for (String slot_string : slot.split(",")) {
-                        InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), Number.getInteger(slot_string));
+                        int slotNumber = Number.getInteger(slot_string);
+                        if (hasMultiplePages && navigationSlots.contains(slotNumber)) {
+                            continue;
+                        }
+                        InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), slotNumber);
                         inventory.setItem(item.getSlot(), item);
                     }
                 } else {
-                    InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), Number.getInteger(slot));
-                    inventory.setItem(item.getSlot(), item);
+                    int slotNumber = Number.getInteger(slot);
+                    if (!(hasMultiplePages && navigationSlots.contains(slotNumber))) {
+                        InteractiveItem item = new InteractiveItem(ItemManager.getItemConfig(Objects.requireNonNull(config.getConfigurationSection("items." + item_tag))), slotNumber);
+                        inventory.setItem(item.getSlot(), item);
+                    }
                 }
             }
         }
@@ -86,5 +140,31 @@ public class PersonalStorage implements IGUI {
 
     public FileConfiguration getConfig() {
         return config;
+    }
+
+    public int getCurrentPage() {
+        return currentPage;
+    }
+
+    private ItemStack getNavigationItem(String itemTag, int currentPage, int totalPages) {
+        ConfigurationSection section = config.getConfigurationSection("items." + itemTag);
+        if (section == null) return null;
+
+        ItemStack itemStack = ItemManager.getItemConfig(section);
+        ItemMeta meta = itemStack.getItemMeta();
+        if (meta == null) return itemStack;
+
+        if (section.getString("name") != null) {
+            String displayName = Chat.colorizewp(Objects.requireNonNull(section.getString("name")).replace("#current_page#", String.valueOf(currentPage + 1)).replace("#total_pages#", String.valueOf(totalPages)));
+            meta.setDisplayName(displayName);
+        }
+
+        if (section.getStringList("lore") != null && !section.getStringList("lore").isEmpty()) {
+            List<String> lore = Chat.colorizewp(section.getStringList("lore").stream().map(s -> s.replace("#current_page#", String.valueOf(currentPage + 1)).replace("#total_pages#", String.valueOf(totalPages))).collect(Collectors.toList()));
+            meta.setLore(lore);
+        }
+
+        itemStack.setItemMeta(meta);
+        return itemStack;
     }
 }

--- a/src/main/java/net/danh/storage/Listeners/Chat.java
+++ b/src/main/java/net/danh/storage/Listeners/Chat.java
@@ -23,6 +23,7 @@ public class Chat implements Listener {
     public static HashMap<Player, String> chat_deposit = new HashMap<>();
     public static HashMap<Player, String> chat_withdraw = new HashMap<>();
     public static HashMap<Player, String> chat_sell = new HashMap<>();
+    public static HashMap<Player, Integer> chat_return_page = new HashMap<>();
 
     @EventHandler(ignoreCancelled = true, priority = EventPriority.HIGHEST)
     public void onChat(@NotNull AsyncPlayerChatEvent e) {
@@ -31,37 +32,37 @@ public class Chat implements Listener {
         if (chat_deposit.containsKey(p) && chat_deposit.get(p) != null) {
             if (Number.getInteger(message) > 0) {
                 new Deposit(p, chat_deposit.get(p), (long) Number.getInteger(message)).doAction();
-                Bukkit.getScheduler().runTask(Storage.getStorage(), () ->
-                        p.openInventory(new PersonalStorage(p).getInventory()));
+                int returnPage = chat_return_page.getOrDefault(p, PersonalStorage.getPlayerCurrentPage(p));
+                Bukkit.getScheduler().runTask(Storage.getStorage(), () -> p.openInventory(new PersonalStorage(p, returnPage).getInventory()));
             } else {
-                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number"))
-                        .replace("<number>", message)));
+                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number")).replace("<number>", message)));
             }
             chat_deposit.remove(p);
+            chat_return_page.remove(p);
             e.setCancelled(true);
         }
         if (chat_withdraw.containsKey(p) && chat_withdraw.get(p) != null) {
             if (Number.getInteger(message) > 0) {
                 new Withdraw(p, chat_withdraw.get(p), Number.getInteger(message)).doAction();
-                Bukkit.getScheduler().runTask(Storage.getStorage(), () ->
-                        p.openInventory(new PersonalStorage(p).getInventory()));
+                int returnPage = chat_return_page.getOrDefault(p, PersonalStorage.getPlayerCurrentPage(p));
+                Bukkit.getScheduler().runTask(Storage.getStorage(), () -> p.openInventory(new PersonalStorage(p, returnPage).getInventory()));
             } else {
-                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number"))
-                        .replace("<number>", message)));
+                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number")).replace("<number>", message)));
             }
             chat_withdraw.remove(p);
+            chat_return_page.remove(p);
             e.setCancelled(true);
         }
         if (chat_sell.containsKey(p) && chat_sell.get(p) != null) {
             if (Number.getInteger(message) > 0) {
                 new Sell(p, chat_sell.get(p), Number.getInteger(message)).doAction();
-                Bukkit.getScheduler().runTask(Storage.getStorage(), () ->
-                        p.openInventory(new PersonalStorage(p).getInventory()));
+                int returnPage = chat_return_page.getOrDefault(p, PersonalStorage.getPlayerCurrentPage(p));
+                Bukkit.getScheduler().runTask(Storage.getStorage(), () -> p.openInventory(new PersonalStorage(p, returnPage).getInventory()));
             } else {
-                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number"))
-                        .replace("<number>", message)));
+                p.sendMessage(net.danh.storage.Utils.Chat.colorize(Objects.requireNonNull(File.getMessage().getString("user.unknown_number")).replace("<number>", message)));
             }
             chat_sell.remove(p);
+            chat_return_page.remove(p);
             e.setCancelled(true);
         }
     }

--- a/src/main/java/net/danh/storage/Listeners/JoinQuit.java
+++ b/src/main/java/net/danh/storage/Listeners/JoinQuit.java
@@ -1,5 +1,6 @@
 package net.danh.storage.Listeners;
 
+import net.danh.storage.GUI.PersonalStorage;
 import net.danh.storage.Manager.MineManager;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -20,5 +21,7 @@ public class JoinQuit implements Listener {
     public void onQuit(@NotNull PlayerQuitEvent e) {
         Player p = e.getPlayer();
         MineManager.savePlayerData(p);
+        PersonalStorage.playerCurrentPage.remove(p);
+        Chat.chat_return_page.remove(p);
     }
 }

--- a/src/main/resources/GUI/storage.yml
+++ b/src/main/resources/GUI/storage.yml
@@ -6,8 +6,7 @@ items:
   # Decorates item
   decorates:
     # If you want to put it on 1 slot | slot: 1 | if you want put it in many slot, do like this
-    slot: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 17, 18, 26, 27, 35, 36, 44, 45, 46, 47, 48,
-      49, 50, 51, 52, 53
+    slot: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 17, 18, 26, 27, 35, 36, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53
     # Display name of item
     name: "&7 "
     # Material | 1.12.2 and below can use STAINED_GLASS_PANE:15
@@ -81,5 +80,37 @@ items:
     enchants:
       DURABILITY: 1
     # Flag for item | If you use ALL: true -> All flag will be applied to item
+    flags:
+      ALL: true
+  # Previous page
+  previous_page:
+    slot: 48
+    name: "&c◀ Previous Page"
+    material: ARROW
+    lore:
+      - "&7Click to go to previous page"
+      - "&7Current: Page &a#current_page#&7/&e#total_pages#"
+    amount: 1
+    damage: 0
+    custom-model-data: 1
+    unbreakable: true
+    enchants:
+      DURABILITY: 1
+    flags:
+      ALL: true
+  # Next page
+  next_page:
+    slot: 50
+    name: "&a▶ Next Page"
+    material: ARROW
+    lore:
+      - "&7Click to go to next page"
+      - "&7Current: Page &a#current_page#&7/&e#total_pages#"
+    amount: 1
+    damage: 0
+    custom-model-data: 1
+    unbreakable: true
+    enchants:
+      DURABILITY: 1
     flags:
       ALL: true


### PR DESCRIPTION
- add pages function in PersonalStorage.java
- add new Placeholder: #current_page# & #total_pages# (only work on config previous_page and next_page)
- update code and some function
### Solved #13 
[2025-07-24+21-09-56.webm](https://github.com/user-attachments/assets/33ec5ca0-825f-4758-91a9-959bb58fe406)

````
blocks:
  COBBLESTONE;0:
    drop: COBBLESTONE;0
  STONE;0:
    drop: COBBLESTONE;0
  COAL_ORE;0:
    drop: COAL;0
  COAL_BLOCK;0:
    drop: COAL_BLOCK;0
  IRON_ORE;0:
    drop: IRON_INGOT;0
  IRON_BLOCK;0:
    drop: IRON_BLOCK;0
  GOLD_ORE;0:
    drop: GOLD_INGOT;0
  GOLD_BLOCK;0:
    drop: GOLD_BLOCK;0
  REDSTONE_ORE;0:
    drop: REDSTONE;0
  REDSTONE_BLOCK;0:
    drop: REDSTONE_BLOCK;0
  LAPIS_ORE;0:
    drop: LAPIS_LAZULI;0
  LAPIS_BLOCK;0:
    drop: LAPIS_BLOCK;0
  DIAMOND_ORE;0:
    drop: DIAMOND;0
  DIAMOND_BLOCK;0:
    drop: DIAMOND_BLOCK;0
  EMERALD_ORE;0:
    drop: EMERALD;0
  EMERALD_BLOCK;0:
    drop: EMERALD_BLOCK;0
  ANCIENT_DEBRIS;0: (new block)
    drop: ANCIENT_DEBRIS;0

items:
  COBBLESTONE;0: '&7Cobblestone'
  COAL;0: '&8Coal'
  COAL_BLOCK;0: '&8Coal Block'
  IRON_INGOT;0: '&fIron Ingot'
  IRON_BLOCK;0: '&fIron Block'
  GOLD_INGOT;0: '&eGolden Ingot'
  GOLD_BLOCK;0: '&eGold Block'
  REDSTONE;0: '&cRedstone'
  REDSTONE_BLOCK;0: '&cRedstone Block'
  LAPIS_LAZULI;0: '&1Lapis Lazuli'
  LAPIS_BLOCK;0: '&1Lapis Block'
  DIAMOND;0: '&bDiamond'
  DIAMOND_BLOCK;0: '&bDiamond Block'
  EMERALD;0: '&aEmerald'
  EMERALD_BLOCK;0: '&aEmerald Block'
  ANCIENT_DEBRIS;0: '&6Ancient Debris' (new block)
  
  storage_item:
    slot: 10, 11, 12, 13, 14, 15, 16, 19, 20, 21, 22, 23, 24, 25, 31
    * If the slot limit is reached, the feature will move the block to a new page and place the new block into the first available slot (slot 10 as configured) on page 2. This applies to all pages 
````

